### PR TITLE
Fixing non-standard SQL statements (fixedsql branch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ secrets/users.rb
 .project
 .settings
 .build
+.buildpath
 
 # Yard:
 .yardoc
@@ -24,3 +25,5 @@ secrets/users.rb
 # Auto generated docs:
 public/docs/epic
 public/docs/yard
+
+hsj

--- a/src/epic_handlevalue.rb
+++ b/src/epic_handlevalue.rb
@@ -173,16 +173,18 @@ class HandleValue # < Resource
       self.ttl_type  = dbrow[:ttl_type].to_i
       self.ttl       = dbrow[:ttl].to_i
       self.timestamp = dbrow[:timestamp].to_i
-      @handle_value.setReferences(
-        dbrow[ :refs ].split("\t").collect do
-          |ref|
-          ref = ref.split ':', 2
-          HS::HDLLIB::ValueReference.new(
-            ref[1].to_java_bytes,
-            ref[0].to_i
-          )
-        end.to_java HS::HDLLIB::ValueReference
-      )
+      if dbrow[:refs]
+        @handle_value.setReferences(
+          dbrow[ :refs ].split("\t").collect do
+            |ref|
+            ref = ref.split ':', 2
+            HS::HDLLIB::ValueReference.new(
+              ref[1].to_java_bytes,
+              ref[0].to_i
+            )
+          end.to_java HS::HDLLIB::ValueReference
+        )
+      end  
       self.admin_read  = dbrow[:admin_read]  && 0 != dbrow[:admin_read]
       self.admin_write = dbrow[:admin_write] && 0 != dbrow[:admin_write]
       self.pub_read    = dbrow[:pub_read]    && 0 != dbrow[:pub_read]

--- a/src/epic_sequel.rb
+++ b/src/epic_sequel.rb
@@ -68,7 +68,7 @@ class DB
     end
     ds = self.pool[:handles].select(:handle).distinct
     if prefix
-      ds = ds.filter( '`handle` LIKE ?', prefix.to_s + '/%' )
+      ds = ds.filter( 'handle LIKE ?', prefix.to_s + '/%' )
     end
     if 0 < limit
       ds = ds.limit( limit, (page - 1) * limit )
@@ -101,12 +101,12 @@ class DB
         select(:handle).
         distinct
       if 'handle' === type
-        tmp_ds = tmp_ds.filter( '`handle` LIKE ?', prefix.to_s + '/' + value )
+        tmp_ds = tmp_ds.filter( 'handle LIKE ?', prefix.to_s + '/' + value )
       else
       	tmp_ds = tmp_ds.
-          filter( '`handle` LIKE ?', prefix.to_s + '/%' ).
-          filter( '`type` = ?', type ).
-          filter( '`data` LIKE ?', value )
+          filter( 'handle LIKE ?', prefix.to_s + '/%' ).
+          filter( 'type = ?', type ).
+          filter( 'data LIKE ?', value )
       end
       ds = ds ? ds.where( :handle => tmp_ds ) : tmp_ds
     end
@@ -125,7 +125,8 @@ class DB
   def all_handle_values handle
     LOGGER.debug_method(self, caller, handle)
     begin
-      ds = self.pool[:handles].where( :handle => handle ).all
+      myquery = self.pool[:handles].where( :handle => handle )
+      ds = myquery.all
     rescue
       msg = "APPLICATION STOPPED: Cannot connect to database!"
       LOGGER.fatal(msg)
@@ -149,7 +150,7 @@ class DB
     ### SELECT AUTO_INCREMENT FROM information_schema.tables WHERE table_name = 'pidsequence';
     ###self.pool['INSERT INTO pidsequence (processID) VALUE (NULL); SELECT LAST_INSERT_ID()'].get
     ###self.pool['SELECT AUTO_INCREMENT FROM information_schema.tables WHERE table_name = "pidsequence"].get
-    self.pool["INSERT INTO `pidsequence` (`processID`) VALUES (NULL)"].insert
+    self.pool["INSERT INTO pidsequence (processID) VALUES (NULL)"].insert
   end
 
 


### PR DESCRIPTION
The changes in this branch fix parts of the non-standard SQL statements. The syntax was only compatible with MySQL but not standard SQL. (In this way Oracle can also be used.)
