### PR TITLE
Fix: #21 Error on reloading HTML format by browser

### DIFF
--- a/src/epic_handle.rb
+++ b/src/epic_handle.rb
@@ -338,7 +338,7 @@ module EPIC
       end.to_s
       retval = [ retval ].pack('H*')
        Debugger.instance.debug("epic_handle.rb:#{__LINE__}:Handle.get_etag sent HTTP-etag: " + "'" + Base64.strict_encode64(retval)[0..-3] + "' to client")
-       "'" + Base64.strict_encode64(retval)[0..-3] + "'"     
+       '"' + Base64.strict_encode64(retval)[0..-3] + '"'     
     end
   
   end # class Handle


### PR DESCRIPTION
ETags are enclosed in double-quotes, not single-quotes. The browser sends back the value in `If-(None-)Match` headers which breaks the header validation on server side. Every second request to the same resource fails because the malformed ETag value from the browser cache is used.
